### PR TITLE
Apply monospace font fix for tabular views

### DIFF
--- a/src/balances/AssetOverviewView.scss
+++ b/src/balances/AssetOverviewView.scss
@@ -12,6 +12,8 @@
   }
 
   th, td {
+    font-variant-numeric: tabular-nums;
+    
     &:first-child {
       padding-left: 28px;
 

--- a/src/exchange/allTrades/AllTradesView.scss
+++ b/src/exchange/allTrades/AllTradesView.scss
@@ -5,6 +5,7 @@
   @include tableColumnsWidth(152px 152px 142px);
 
   td, th {
+    font-variant-numeric: tabular-nums;
     // time column
     &:last-child {
       flex-grow: 1;

--- a/src/exchange/myTrades/MyTradesView.scss
+++ b/src/exchange/myTrades/MyTradesView.scss
@@ -20,6 +20,8 @@
   max-height: 400px;
 
   td, th {
+    font-variant-numeric: tabular-nums;
+
     &:first-child {
       padding-left: 16px;
       @include media-breakpoint-up(lg) {

--- a/src/exchange/orderbook/OrderbookView.scss
+++ b/src/exchange/orderbook/OrderbookView.scss
@@ -31,6 +31,8 @@
   @include tableColumnsWidth(146px 146px 146px);
 
   td, th {
+    font-variant-numeric: tabular-nums;
+
     &:last-child {
       flex-grow: 1;
     }


### PR DESCRIPTION
Quick css fix for misaligned numbers in tabular views (Trade History, Order Book, My Orders, Account Overview). Css fix makes numbers (only) in this table monospace, therefore coma/dot separators align correctly.


Before:
<img width="446" alt="font-before" src="https://user-images.githubusercontent.com/603495/68770900-49362d80-0627-11ea-878f-3ff5169e2621.png">

After:
<img width="446" alt="font-after" src="https://user-images.githubusercontent.com/603495/68770916-518e6880-0627-11ea-8947-913c642d92d6.png">

